### PR TITLE
Add log-level helper

### DIFF
--- a/src/log-level.js
+++ b/src/log-level.js
@@ -1,0 +1,39 @@
+import {retry} from "./retry-fn.js";
+
+const GCS_SERVICE_URL = "https://storage.googleapis.com/storage/v1/b/risevision-endpoint-loglevels/o/ENDPOINT_ID.json?alt=media";
+
+let refreshDate = localStorage.getItem("bq-endpoint-logger-fetchdate");
+let level = localStorage.getItem("bq-endpoint-logger-level");
+let serviceUrl = null;
+
+const THROTTLE_MAX_5_MIN = 300000;
+
+const recentlyFetched = ()=>new Date() - (refreshDate || 0) < THROTTLE_MAX_5_MIN;
+
+export const getLogLevel = ()=>{
+  if (level && recentlyFetched()) {return Promise.resolve(level);}
+
+  return retry(()=>fetch(serviceUrl))
+  .then(resp=>{
+    refreshDate = new Date();
+    return resp.json();
+  })
+  .then(json=>{
+    level = json.logLevel || "ERROR";
+    localStorage.setItem("bq-endpoint-logger-level", level);
+    localStorage.setItem("bq-endpoint-logger-fetchdate", refreshDate);
+    return level;
+  })
+  .catch(err=>{
+    console.error(err);
+    return Promise.resolve(level || "ERROR");
+  });
+};
+
+export const setUrl = id=>{
+  serviceUrl = GCS_SERVICE_URL.replace("ENDPOINT_ID", id);
+};
+
+export const reset = ()=>{
+  level = null;
+}

--- a/src/log-level.test.js
+++ b/src/log-level.test.js
@@ -1,0 +1,60 @@
+import {getLogLevel, reset} from "./log-level.js";
+
+describe.only("Log Level", ()=>{ // eslint-disable-line max-lines-per-function
+  before(()=>{
+    window.setTimeoutOrig = window.setTimeout;
+    window.fetchOrig = window.fetch;
+  });
+
+  afterEach(()=>{
+    window.setTimeout = window.setTimeoutOrig;
+    window.fetch = window.fetchOrig;
+    reset();
+  });
+
+  it("retrieves log level", ()=>{
+    window.fetch = ()=>{
+      return Promise.resolve({json(){return {logLevel: "INFO"}}});
+    };
+
+    return getLogLevel()
+    .then(level=>assert.equal(level, "INFO"));
+  });
+
+  it("doesn't fetch when recently retrieved", ()=>{
+    let secondAttempt = false;
+
+    window.fetch = ()=>{
+      return Promise.resolve({json(){return {logLevel: "INFO"}}});
+    };
+
+    return getLogLevel()
+    .then(()=>{
+      window.fetch = ()=>{
+        return Promise.reject(Error("test-error"));
+      };
+
+      window.setTimeout = (fn, ms)=>{
+        secondAttempt = true;
+        return window.setTimeoutOrig(fn, ms / 50);
+      };
+
+      return getLogLevel()
+    })
+    .then(level=>{
+      assert.equal(level, "INFO");
+      assert.equal(secondAttempt, false);
+    });
+  });
+
+  it("returns default ERROR level when level cannot be retrieved", ()=>{
+    window.setTimeout = (fn, ms)=>window.setTimeoutOrig(fn, ms / 50);
+
+    window.fetch = ()=>{
+      return Promise.reject(Error("test-error"));
+    };
+
+    return getLogLevel()
+    .then(level=>assert.equal(level, "ERROR"));
+  });
+});


### PR DESCRIPTION
## Description
Add log level helper.

## Motivation and Context
The logger is only logging ERROR severity by default.

## How Has This Been Tested?
Unit test.
Will incorporate into the next PR as part of logger.info call and further test it then.

## Design / Documentation

For changes, a mini-design [should be included] with multiple [considerations] and distribution.

[Documentation] should be updated / created to reflect the post-merge state.

 - [x] Architecture / Design doc is [included](https://docs.google.com/document/d/1ifKL-xjC1nqPJoVZmXoP4gKDpncKwuWKSGj-zcdqzqY/edit#)
 - [ ] Architecture / Design doc is not included because the change is trivial (eg: Readme update)

 - [x] Architecture / Design doc has been distributed
 - [ ] Architecture / Design doc has not been distributed

 - [x] Documentation is part of a future card
 - [ ] Documentation is not needed because the change is trivial (eg: Readme
   update)

[should be included]: https://docs.google.com/document/d/1l-qMt55yYzql9DlwqyPHftUb120f-xNRyK3Rspird2w/edit#heading=h.2g0bwllttzin
[considerations]:
https://docs.google.com/document/d/12UT3FtX5eGy40Ke0bNxac0aEcVl7Z9pewMW9ZwWnpfs/edit?ts=5fa243fb#bookmark=id.5f9yuibn0j4v
[Documentation]: https://drive.google.com/drive/folders/1YAMp2-VWCfUvtubZGqDwhF2e-5z1Xxtb
