### PR TITLE
Allow init fields to be overridden by later log calls

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -75,26 +75,26 @@ export const init = (initConfig = {})=>{
       }
 
       return streamHeartbeatTableEntry({
-        ...config,
         endpointId: initConfig.endpointId,
         endpointType: initConfig.endpointType,
-        scheduleId: initConfig.scheduleId
+        scheduleId: initConfig.scheduleId,
+        ...config
       });
     },
     info(config = {}) {
-      return recordLogType("INFO", {...config, ...initConfig});
+      return recordLogType("INFO", {...initConfig, ...config});
     },
     error(config = {}) {
-      return recordLogType("ERROR", {...config, ...initConfig});
+      return recordLogType("ERROR", {...initConfig, ...config});
     },
     warning(config = {}) {
-      return recordLogType("WARNING", {...config, ...initConfig});
+      return recordLogType("WARNING", {...initConfig, ...config});
     },
     debug(config = {}) {
-      return recordLogType("DEBUG", {...config, ...initConfig});
+      return recordLogType("DEBUG", {...initConfig, ...config});
     },
     important(config = {}) {
-      return recordLogType("IMPORTANT", {...config, ...initConfig});
+      return recordLogType("IMPORTANT", {...initConfig, ...config});
     },
     getRiseFileRequestParameters() {
       return gcsFileRequestParameters;


### PR DESCRIPTION
## Description
Allow init fields to be overridden by later log calls when more info might be available

## Motivation and Context
In some cases (eg scheduleId not in a shared schedule) a field might not be available at init time, but becomes available later.

## How Has This Been Tested?
Unit+manual

## Design / Documentation

For changes, a mini-design [should be included] with multiple [considerations] and distribution.

[Documentation] should be updated / created to reflect the post-merge state.

 - [x] Architecture / Design doc is [included](https://docs.google.com/document/d/1ifKL-xjC1nqPJoVZmXoP4gKDpncKwuWKSGj-zcdqzqY/edit#)
 - [ ] Architecture / Design doc is not included because the change is trivial (eg: Readme update)

 - [x] Architecture / Design doc has been distributed
 - [ ] Architecture / Design doc has not been distributed

 - [x] Documentation is part of a separate card
 - [ ] Documentation is not needed because the change is trivial (eg: Readme
   update)

[should be included]: https://docs.google.com/document/d/1l-qMt55yYzql9DlwqyPHftUb120f-xNRyK3Rspird2w/edit#heading=h.2g0bwllttzin
[considerations]:
https://docs.google.com/document/d/12UT3FtX5eGy40Ke0bNxac0aEcVl7Z9pewMW9ZwWnpfs/edit?ts=5fa243fb#bookmark=id.5f9yuibn0j4v
[Documentation]: https://drive.google.com/drive/folders/1YAMp2-VWCfUvtubZGqDwhF2e-5z1Xxtb
