### PR TITLE
Include event severity automatically based on event type

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -53,7 +53,7 @@ const recordLogType = (type = "INFO", config)=>{
 
   return getLogLevel()
     .then(level=>type === "IMPORTANT" || levels.indexOf(type) >= levels.indexOf(level) ?
-      streamEventsTableEntry(config) :
+      streamEventsTableEntry({eventSeverity: type, ...config}) :
       Promise.resolve());
 }
 

--- a/src/logger.test.js
+++ b/src/logger.test.js
@@ -46,7 +46,7 @@ describe("Logger", ()=>{ // eslint-disable-line max-lines-per-function
   });
 
   describe("Logger INFO", ()=>{ // eslint-disable-line max-lines-per-function
-    it("includes endpointId from init fields", ()=>{
+    it("includes endpointId from init fields and severity from type", ()=>{
       let fetchedUrls = [];
       let loggedData = {};
 
@@ -62,7 +62,8 @@ describe("Logger", ()=>{ // eslint-disable-line max-lines-per-function
         eventDetails: "test-event-details"
       })
       .then(()=>assert(fetchedUrls.some(url=>url.includes("eventLog/insertAll"))))
-      .then(()=>assert(loggedData.body.includes("test-endpoint-id")));
+      .then(()=>assert(loggedData.body.includes("test-endpoint-id")))
+      .then(()=>assert(loggedData.body.includes("\"eventSeverity\":\"INFO\"")));
     });
 
     it("doesn't log INFO level by default", ()=>{


### PR DESCRIPTION
## Description
This change improves usability of the library.
Clients / callers shouldn't have to include eventSeverity as it is implied in the method name (ie: error, debug, warning, info, important).

## Motivation and Context
Minor usability improvement

## How Has This Been Tested?
Unit + local + staging

## Design / Documentation

For changes, a mini-design [should be included] with multiple [considerations] and distribution.

[Documentation] should be updated / created to reflect the post-merge state.

 - [x] Architecture / Design doc is [included](https://docs.google.com/document/d/1oAmA8cQGJqFeDO8sWtulRxE0sT5TZi0I_l6S_rN6GOU/edit#)
 - [ ] Architecture / Design doc is not included because the change is trivial (eg: Readme update)

 - [ ] Architecture / Design doc has been distributed
 - [x] Architecture / Design doc has not been distributed

 - [x] Documentation will be created as part of a separate card
 - [ ] Documentation is not needed because the change is trivial (eg: Readme
   update)

[should be included]: https://docs.google.com/document/d/1l-qMt55yYzql9DlwqyPHftUb120f-xNRyK3Rspird2w/edit#heading=h.2g0bwllttzin
[considerations]:
https://docs.google.com/document/d/12UT3FtX5eGy40Ke0bNxac0aEcVl7Z9pewMW9ZwWnpfs/edit?ts=5fa243fb#bookmark=id.5f9yuibn0j4v
[Documentation]: https://drive.google.com/drive/folders/1YAMp2-VWCfUvtubZGqDwhF2e-5z1Xxtb
